### PR TITLE
Compress episode list on homepage

### DIFF
--- a/source/_episode_row.html.slim
+++ b/source/_episode_row.html.slim
@@ -1,0 +1,10 @@
+.episode
+  h3.name = link_to "#{episode.data.episode}: #{episode.title}", episode
+
+  .row.details
+    span.date = episode.date.strftime('%b %e')
+    span.duration = " (#{episode.data.seconds/60} minutes)"
+    .mp3 = link_to "mp3", episode.data.mp3
+
+  .row
+    article.body = episode.body.lines.first

--- a/source/index.html.slim
+++ b/source/index.html.slim
@@ -1,2 +1,4 @@
-- episodes.each do |episode|
-  = partial 'episode', locals: { episode: episode }
+- first_episode, *episodes_rows = episodes
+= partial 'episode', locals: { episode: first_episode }
+- episodes_rows.each do |episode|
+  = partial 'episode_row', locals: { episode: episode }


### PR DESCRIPTION
On the homepage, show the entire first episode body, but only show the first line for subsequent episodes.

This should probably be refactored to use middleman-blog summary engine thingy.
