### PR TITLE
Disable slim option validation

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -1,3 +1,5 @@
+Slim::Engine.disable_option_validator!
+
 set :css_dir, 'stylesheets'
 set :js_dir, 'javascripts'
 set :images_dir, 'images'


### PR DESCRIPTION
Prevents the following messages from being output:

```
Option :locals is not supported by Slim::Engine
Option :layout_engine is not supported by Slim::Engine
```
