### PR TITLE
Add Picks to podcast feed

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -46,6 +46,10 @@ helpers do
     blog.articles
   end
 
+  def picks_partial(episode)
+    partial "picks", locals: { episode_picks: episode.data['picks'] }
+  end
+
   def feedburner_url
     "http://feeds.feedburner.com/Turing-Incomplete"
   end

--- a/source/_episode.html.slim
+++ b/source/_episode.html.slim
@@ -12,7 +12,7 @@
   .row
     article.body = episode.body
 
-    = partial "picks", locals: { episode_picks: episode.data['picks'] }
+    = picks_partial(episode)
 
   .row
     .audio-wrapper

--- a/source/podcast.xml.builder
+++ b/source/podcast.xml.builder
@@ -39,7 +39,7 @@ xml.rss(
         xml.title "#{metadata.episode}: #{metadata.title}"
         xml.link url(episode.url)
         xml.description episode_text
-        xml.content :encoded, episode.body + partial(:shownotes_footer, locals: { episode: episode })
+        xml.content :encoded, episode.body + picks_partial(episode) + partial(:shownotes_footer, locals: { episode: episode })
         xml.pubDate (episode.date + (15 * 60 * 60)).strftime("%a, %d %b %Y %H:%M:%S %z")
         xml.guid url(episode.url), isPermaLink: "true"
         xml.media :content, url: metadata.mp3, type: "audio/mpeg", fileSize: metadata.file_size


### PR DESCRIPTION
Overcast displays what's in the content:encoded but doesn't include
picks like the website does. This adds it in.